### PR TITLE
SliceMapCollector with SliceMap creation performance improvements

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -13,15 +13,11 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="examples"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry exported="true" kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/jdk1.8.0_31"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/org/jcvi/jillion/assembly/util/SliceBuilder.java
+++ b/src/org/jcvi/jillion/assembly/util/SliceBuilder.java
@@ -272,8 +272,8 @@ public final class SliceBuilder implements Builder<Slice>{
     	}else{    		
           //overwrite
     		bytes.replace(index, (short)value);
-    		ids.remove(index);
-    		ids.add(index, id);
+//    		ids.remove(index);
+//    		ids.add(index, id);
     	}
     	
         

--- a/src/org/jcvi/jillion/assembly/util/SliceBuilder.java
+++ b/src/org/jcvi/jillion/assembly/util/SliceBuilder.java
@@ -239,6 +239,11 @@ public final class SliceBuilder implements Builder<Slice>{
         }
         
     }
+    
+    protected void mergeNew(SliceBuilder other){
+        this.ids.addAll(other.ids);
+        this.bytes.append(other.bytes);
+    }
     /**
      * Add a new SliceElement with the following values
      * to this builder.
@@ -277,6 +282,43 @@ public final class SliceBuilder implements Builder<Slice>{
     	}
     	
         
+        return this;
+    }
+    
+    /**
+     * Add a new SliceElement with the following values
+     * to this builder.  This method is the same as {@link #add(String, Nucleotide, PhredQuality, Direction)}
+     * except it does not do any checks to see if this Slice already has this id 
+     * so this method should only be called when it is guaranteed that the id is unique in this slice.
+     * Adding a SliceElement with the same id
+     * as a pre-existing element already
+     * present in this builder will cause the new
+     * value to overwrite the existing value.
+     * 
+     * @param id the id of the SliceElement to add;
+     * can not be null.
+     * @param base the {@link Nucleotide} basecall of the SliceElement to add;
+     * can not be null.
+     * @param quality the {@link PhredQuality} of the SliceElement to add;
+     * can not be null.
+     * @param dir the {@link Direction} of the SliceElement to add;
+     * can not be null.
+     * @return this
+     * @throws NullPointerException if any parameter is null.
+     * 
+     * @since 5.3
+     */
+    SliceBuilder addNew(String id, Nucleotide base, PhredQuality quality, Direction dir){
+
+        CompactedSliceElement compacted = new CompactedSliceElement(id, base,
+                quality, dir);
+        int value = compacted.getEncodedDirAndNucleotide() << 8;
+        value |= (compacted.getEncodedQuality() & 0xFF);
+
+        // append
+        bytes.append((short) value);
+        ids.add(id);
+
         return this;
     }
 
@@ -340,6 +382,9 @@ public final class SliceBuilder implements Builder<Slice>{
 		return "SliceBuilder [bytes=" + bytes + ", ids=" + ids + ", consensus="
 				+ consensus + "]";
 	}
+    public boolean isEmpty() {
+        return ids.isEmpty();
+    }
 
 
 }

--- a/src/org/jcvi/jillion/assembly/util/SliceCombiner.java
+++ b/src/org/jcvi/jillion/assembly/util/SliceCombiner.java
@@ -1,0 +1,66 @@
+package org.jcvi.jillion.assembly.util;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import org.jcvi.jillion.core.Direction;
+import org.jcvi.jillion.core.qual.PhredQuality;
+import org.jcvi.jillion.core.residue.nt.Nucleotide;
+import org.jcvi.jillion.core.residue.nt.NucleotideSequence;
+
+/**
+ * Helper class used by {@link SliceMapCollector}.
+ * 
+ * @author dkatzel
+ *
+ * @since 5.3
+ */
+final class SliceCombiner {
+
+    private final SliceBuilder[] builders;
+    
+    
+    public SliceCombiner(int size){
+        builders = new SliceBuilder[size];
+        Arrays.parallelSetAll(builders , i-> new SliceBuilder());
+    }
+    public void add(String id, int start, NucleotideSequence seq, Iterator<PhredQuality> qualities, Direction dir){
+        int i =0;
+        for(Nucleotide base : seq){
+                PhredQuality quality = qualities.next();
+                SliceBuilder builder = builders[start+i];
+                synchronized (builder) {
+                    builder.addNew(id, base, quality, dir);
+                }
+                i++;
+        }
+    }
+    
+    public SliceCombiner combine(SliceCombiner other){
+        for(int i=0; i< builders.length; i++){
+            SliceBuilder otherBuilder = other.builders[i];
+            if(!otherBuilder.isEmpty()){
+                
+                SliceBuilder myBuilder = builders[i];
+                synchronized (myBuilder) {
+                    myBuilder.mergeNew(otherBuilder);
+                }
+               
+            }
+        }
+        return this;
+    }
+    
+    public synchronized Slice[] toSlices(NucleotideSequence consensus){
+        Slice[] ret = new Slice[builders.length];
+        int i=0;
+        for(Nucleotide n : consensus){
+            ret[i] = builders[i].setConsensus(n).build();
+            i++;
+        }
+        return ret;
+        
+    }
+    
+    
+}

--- a/src/org/jcvi/jillion/assembly/util/SliceMapCollector.java
+++ b/src/org/jcvi/jillion/assembly/util/SliceMapCollector.java
@@ -1,0 +1,264 @@
+package org.jcvi.jillion.assembly.util;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.jcvi.jillion.assembly.AssembledRead;
+import org.jcvi.jillion.core.Direction;
+import org.jcvi.jillion.core.datastore.DataStoreException;
+import org.jcvi.jillion.core.qual.PhredQuality;
+import org.jcvi.jillion.core.qual.QualitySequence;
+import org.jcvi.jillion.core.qual.QualitySequenceDataStore;
+import org.jcvi.jillion.core.residue.nt.NucleotideSequence;
+import org.jcvi.jillion.core.util.iter.ArrayIterator;
+/**
+ * Collectors to turn a Stream of reads into a SliceMap.
+ * 
+ * <p>
+ * The following examples show some example usages:
+ * 
+ * <pre>
+ * {@code
+ //CONVERT CONTIG TO SLICE MAP USING DEFAULT QUALITY VALUE:
+ SliceMap sliceMap =  contig.reads()
+                            .parallel()
+                            .collect(SliceMapCollector.toSliceMap(contig.getConsensusSequence()));
+                            
+ //CONVERT CONTIG TO SLICE MAP FROM PARALLEL STREAM:
+ SliceMap sliceMap =  contig.reads()
+                            .parallel()
+                            .collect(SliceMapCollector.toSliceMap(contig.getConsensusSequence(), qualityDataStore));
+ * 
+ * }
+ * </pre>
+ * </p>
+ * 
+ * @author dkatzel
+ *
+ * @since 5.3
+ */
+public final class SliceMapCollector implements Collector<AssembledRead, SliceCombiner, SliceMap>{
+    private static final Set<java.util.stream.Collector.Characteristics> UNORDERED_AND_CONCURRENT = EnumSet.of(Collector.Characteristics.UNORDERED,
+            Collector.Characteristics.CONCURRENT
+);
+    private static final PhredQuality DEFAULT_QUALITY = PhredQuality.valueOf(30);
+    /**
+     * Returns a Collector that creates a SliceMap from a stream of {@link AssembledRead}s
+     * with all qualities in the SliceMap faked to be the default quality value (30).
+     * 
+     * @param consensus the consensus sequence of the contig that the assembled reads are from.
+     * @return a new Collector.
+     */
+    public static SliceMapCollector toSliceMap(NucleotideSequence consensus){
+        return toSliceMap(consensus, GapQualityValueStrategy.LOWEST_FLANKING, DEFAULT_QUALITY);
+    }
+    /**
+     * Returns a Collector that creates a SliceMap from a stream of {@link AssembledRead}s
+     * with all qualities in the SliceMap faked to be the default quality value (30).
+     * 
+     * @param consensus the consensus sequence of the contig that the assembled reads are from.
+     * @param qualityValueStrategy the {@link GapQualityValueStrategy} used to compute the qualities of gaps in the reads.
+     * @return a new Collector.
+     */
+    public static SliceMapCollector toSliceMap(NucleotideSequence consensus, GapQualityValueStrategy qualityValueStrategy){
+        return toSliceMap(consensus, qualityValueStrategy, DEFAULT_QUALITY);
+    }
+    /**
+     * Returns a Collector that creates a SliceMap from a stream of {@link AssembledRead}s
+     * with all qualities in the SliceMap faked to be given default quality value.
+     * 
+     * @param consensus the consensus sequence of the contig that the assembled reads are from.
+     * @param qualityValueStrategy the {@link GapQualityValueStrategy} used to compute the qualities of gaps in the reads.
+     * @param defaultQuality the {@link PhredQuality} to use for all non-gap bases in the slices.
+     * 
+     * @return a new Collector.
+     */
+public static SliceMapCollector toSliceMap(NucleotideSequence consensus, GapQualityValueStrategy qualityValueStrategy, PhredQuality defaultQuality){
+    return toSliceMap(consensus, qualityValueStrategy, null, DEFAULT_QUALITY);
+    }
+/**
+ * Returns a Collector that creates a SliceMap from a stream of {@link AssembledRead}s
+ * with all qualities in the SliceMap faked to be given default quality value.
+ * 
+ * @param consensus the consensus sequence of the contig that the assembled reads are from.
+ * @param qualityValueStrategy the {@link GapQualityValueStrategy} used to compute the qualities of gaps in the reads.
+ * @param qualities the {@link QualitySequenceDataStore} to use to look up the read's quality values.
+ * 
+ * @return a new Collector.
+ */
+public static SliceMapCollector toSliceMap(NucleotideSequence consensus, GapQualityValueStrategy qualityValueStrategy, QualitySequenceDataStore qualities){
+    return toSliceMap(consensus, qualityValueStrategy, qualities, DEFAULT_QUALITY);
+    
+}
+/**
+ * Returns a Collector that creates a SliceMap from a stream of {@link AssembledRead}s
+ * with all qualities in the SliceMap faked to be given default quality value.
+ * 
+ * @param consensus the consensus sequence of the contig that the assembled reads are from.
+ * @param qualityValueStrategy the {@link GapQualityValueStrategy} used to compute the qualities of gaps in the reads.
+ * @param qualities the {@link QualitySequenceDataStore} to use to look up the read's quality values.
+ * @param defaultQuality the {@link PhredQuality} to use for all non-gap bases in the slices for reads that are not found
+ * in the quality datastore.
+ * 
+ * @return a new Collector.
+ */
+public static SliceMapCollector toSliceMap(NucleotideSequence consensus, GapQualityValueStrategy qualityValueStrategy, QualitySequenceDataStore qualities, PhredQuality defaultQuality){
+    return new SliceMapCollector(consensus, qualities, qualityValueStrategy, defaultQuality);
+    
+}
+    private final NucleotideSequence consensus;
+    private final QualitySequenceDataStore qualityDataStore;
+    private final GapQualityValueStrategy qualityValueStrategy;
+    private final PhredQuality defaultQuality;
+    
+    
+    private SliceMapCollector(NucleotideSequence consensus,
+            QualitySequenceDataStore qualityDataStore,
+            GapQualityValueStrategy qualityValueStrategy,
+            PhredQuality defaultQuality) {
+        this.consensus = consensus;
+        this.qualityDataStore = qualityDataStore;
+        this.qualityValueStrategy = qualityValueStrategy;
+        this.defaultQuality = defaultQuality;
+    }
+
+    @Override
+    public Supplier<SliceCombiner> supplier() {
+        return ()-> new SliceCombiner((int)consensus.getLength());
+    }
+
+    @Override
+    public BiConsumer<SliceCombiner, AssembledRead> accumulator() {
+        return this::addRead;
+    }
+    
+    private void addRead(SliceCombiner combiner, AssembledRead read){
+        int start = (int)read.getGappedStartOffset();
+        String id =read.getId();
+        Direction dir = read.getDirection();
+        Iterator<PhredQuality> validRangeGappedQualitiesIterator =null;
+        if(qualityDataStore==null){
+                validRangeGappedQualitiesIterator = createNewDefaultQualityIterator(defaultQuality);
+
+        }else{
+                QualitySequence fullQualities;
+                try {
+                    fullQualities = qualityDataStore.get(id);
+                } catch (DataStoreException e) {
+                   throw new RuntimeException("error processing quality data for " + id);
+                }
+                
+                if(fullQualities ==null){
+                        throw new NullPointerException("could not get qualities for "+id);
+                }
+                validRangeGappedQualitiesIterator = qualityValueStrategy.getGappedValidRangeQualitySequenceFor(read, fullQualities)
+                                                                                                .iterator();
+                
+        }
+        combiner.add(id, start, read.getNucleotideSequence(), validRangeGappedQualitiesIterator, dir);
+    }
+
+    @Override
+    public BinaryOperator<SliceCombiner> combiner() {
+        return (a,b)-> a.combine(b);
+    }
+
+    @Override
+    public Function<SliceCombiner, SliceMap> finisher() {        
+        return this::toSliceMap;
+    }
+
+    private SliceMap toSliceMap(SliceCombiner combiner){
+        Slice[] slices = combiner.toSlices(consensus);
+        return new CollectedSliceMap(slices);
+    }
+    
+    @Override
+    public Set<java.util.stream.Collector.Characteristics> characteristics() {
+        return UNORDERED_AND_CONCURRENT;
+    }
+
+    private Iterator<PhredQuality> createNewDefaultQualityIterator(
+            final PhredQuality defaultQuality) {
+    return new Iterator<PhredQuality>(){
+                    
+            @Override
+            public boolean hasNext() {
+                    //always return true
+                    return true;
+            }
+            @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+                            value = {"IT_NO_SUCH_ELEMENT"}, 
+                            justification = "only used for fake data will never have no such element exception")                            
+            @Override
+            public PhredQuality next() {
+                    return defaultQuality;
+            }
+
+            @Override
+            public void remove() {
+                    //no-op                         
+            }
+            
+    };
+}
+    private static class CollectedSliceMap implements SliceMap{
+        private final Slice[] slices;
+        
+        protected CollectedSliceMap(Slice[] slices) {
+            this.slices = slices;
+        }
+
+        @Override
+        public Iterator<Slice> iterator() {
+            return new ArrayIterator<Slice>(slices, false);
+        }
+
+        @Override
+        public Slice getSlice(long offset) {
+            return slices[(int)offset];
+        }
+
+        @Override
+        public long getSize() {
+            return slices.length;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Arrays.hashCode(slices);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!(obj instanceof CollectedSliceMap)) {
+                return false;
+            }
+            CollectedSliceMap other = (CollectedSliceMap) obj;
+            if (!Arrays.equals(slices, other.slices)) {
+                return false;
+            }
+            return true;
+        }
+        
+    }
+   
+    
+    
+}

--- a/src/org/jcvi/jillion/internal/assembly/util/NoConsensusCompactedSlice.java
+++ b/src/org/jcvi/jillion/internal/assembly/util/NoConsensusCompactedSlice.java
@@ -22,6 +22,7 @@ package org.jcvi.jillion.internal.assembly.util;
 
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -108,16 +109,23 @@ public class NoConsensusCompactedSlice implements Slice{
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + Arrays.hashCode(elements);
-		result = prime * result + Arrays.hashCode(ids);
-		Nucleotide consensusCall = getConsensusCall();
-		if(consensusCall !=null){
-			result = prime * result + consensusCall.hashCode();
-		}
+		//this is so 2 Slices that have the same ids but in different order still have same hashcode
+		result = prime * result + sum(elements);
+		
+		result = prime * result + new HashSet<>(Arrays.asList(ids)).hashCode();
+		
+		
 		
 		return result;
 	}
 
+	private static int sum(short[] s){
+	    int sum=0;
+	    for(int i=0; i< s.length; i++){
+	        sum +=s[i];
+	    }
+	    return sum;
+	}
 	@Override
 	public boolean equals(Object obj) {
         if (this == obj){

--- a/test/org/jcvi/jillion/assembly/util/AllSliceUnitTests.java
+++ b/test/org/jcvi/jillion/assembly/util/AllSliceUnitTests.java
@@ -46,6 +46,9 @@ import org.junit.runners.Suite.SuiteClasses;
         TestSliceMapBuilderUsingQualityDataStore.class,
         TestSliceMapBuilderUsingDefaultQualities.class,
         
+        TestParallelSliceCollector.class,
+        TestSliceCollector.class,
+        
         TestSliceMapBuilderReadFilter.class,
         
         AllConsensusUnitTests.class

--- a/test/org/jcvi/jillion/assembly/util/TestParallelSliceCollector.java
+++ b/test/org/jcvi/jillion/assembly/util/TestParallelSliceCollector.java
@@ -1,0 +1,19 @@
+package org.jcvi.jillion.assembly.util;
+
+import org.jcvi.jillion.assembly.AssembledRead;
+import org.jcvi.jillion.assembly.Contig;
+import org.jcvi.jillion.core.qual.QualitySequenceDataStore;
+
+public class TestParallelSliceCollector extends AbstractTestSliceMap{
+
+    @Override
+    protected SliceMap createSliceMapFor(Contig<AssembledRead> contig,
+            QualitySequenceDataStore qualityDatastore,
+            GapQualityValueStrategy qualityValueStrategy) {
+        
+        return contig.reads()
+                .parallel()
+                        .collect(SliceMapCollector.toSliceMap(contig.getConsensusSequence(), qualityValueStrategy, qualityDatastore));
+    }
+
+}

--- a/test/org/jcvi/jillion/assembly/util/TestSliceCollector.java
+++ b/test/org/jcvi/jillion/assembly/util/TestSliceCollector.java
@@ -1,0 +1,18 @@
+package org.jcvi.jillion.assembly.util;
+
+import org.jcvi.jillion.assembly.AssembledRead;
+import org.jcvi.jillion.assembly.Contig;
+import org.jcvi.jillion.core.qual.QualitySequenceDataStore;
+
+public class TestSliceCollector extends AbstractTestSliceMap{
+
+    @Override
+    protected SliceMap createSliceMapFor(Contig<AssembledRead> contig,
+            QualitySequenceDataStore qualityDatastore,
+            GapQualityValueStrategy qualityValueStrategy) {
+        
+        return contig.reads()
+                        .collect(SliceMapCollector.toSliceMap(contig.getConsensusSequence(), qualityValueStrategy, qualityDatastore));
+    }
+
+}


### PR DESCRIPTION
Created new SliceMapCollector class which uses new faster methods to create SliceMaps faster.  Testing showed 6x performance improvement over iterator and 2x performance improvement over parallel stream using old builder methods